### PR TITLE
Update Git repo location in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Parallelization in Swiftest is done with OpenMP. Version 3.1.4 or higher is nece
 The easiest way to get Swiftest on your machine is to clone the GitHub repository. To do so, open a terminal window and type the following:
 
 ```
-$ git clone https://github.itap.purdue.edu/MintonGroup/swiftest.git
+$ git clone https://github.com/carlislewishard/swiftest.git
 ```
 
 If your cloned version is not already set to the master branch:


### PR DESCRIPTION
I followed the installation instructions in the README, cloned from the Purdue repo and ran into an issue (using `.not.` on an integer) that appears to have [been fixed](https://github.com/carlislewishard/swiftest/commit/297dedf577f0a22955f488b8e64a9985cc676352) in the GitHub version, so I presume the README needs to be updated.