### PR TITLE
removed -l flag from command in Popen. Closes #14.

### DIFF
--- a/python/swiftest/swiftest/simulation_class.py
+++ b/python/swiftest/swiftest/simulation_class.py
@@ -405,7 +405,7 @@ class Simulation(object):
 
         # Get current environment variables
         env = os.environ.copy()
-        cmd = f"{env['SHELL']} -l {self.driver_script}"
+        cmd = f"{env['SHELL']} {self.driver_script}"
         
 
         def _type_scrub(output_data):


### PR DESCRIPTION
I think the issue #14 is related to the command that you pass to subprocess.Popen. You call `bash` with the `-l` flag. This makes bash act as if it had been a login shell. Maybe there is a reason for why you would want that? However, if I remove this flag I don't have this issues anymore.